### PR TITLE
Integrate persona library selections and automation launcher

### DIFF
--- a/CLAUDE_CODE/ai_sales_training/package-lock.json
+++ b/CLAUDE_CODE/ai_sales_training/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@supabase/supabase-js": "^2.57.4",
         "@tailwindcss/postcss": "^4.1.13",
         "@types/node": "^22.7.0",
         "@types/react": "^18.3.8",
@@ -3060,6 +3061,123 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.71.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
+      "integrity": "sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.6.tgz",
+      "integrity": "sha512-bhjZ7rmxAibjgmzTmQBxJU6ZIBCCJTc3Uwgvdi4FewueUTAGO5hxZT1Sj6tiD+0dSXf9XI87BDdJrg12z8Uaew==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@supabase/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.21.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.21.4.tgz",
+      "integrity": "sha512-TxZCIjxk6/dP9abAi89VQbWWMBbybpGWyvmIzTd79OeravM13OjR/YEYeyUOPcM1C3QyvXkvPZhUfItvmhY1IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.15.5",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.5.tgz",
+      "integrity": "sha512-/Rs5Vqu9jejRD8ZeuaWXebdkH+J7V6VySbCZ/zQM93Ta5y3mAmocjioa/nzlB6qvFmyylUgKVS1KpE212t30OA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/realtime-js/node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.12.1.tgz",
+      "integrity": "sha512-QWg3HV6Db2J81VQx0PqLq0JDBn4Q8B1FYn1kYcbla8+d5WDmTdwwMr+EJAxNOSs9W4mhKMv+EYCpCrTFlTj4VQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.57.4",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.57.4.tgz",
+      "integrity": "sha512-LcbTzFhHYdwfQ7TRPfol0z04rLEyHabpGYANME6wkQ/kLtKNmI+Vy+WEM8HxeOZAtByUFxoUTTLwhXmrh+CcVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.71.1",
+        "@supabase/functions-js": "2.4.6",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.21.4",
+        "@supabase/realtime-js": "2.15.5",
+        "@supabase/storage-js": "2.12.1"
+      }
+    },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
@@ -3825,6 +3943,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
       "license": "MIT"
     },
     "node_modules/@types/prettier": {

--- a/CLAUDE_CODE/ai_sales_training/package.json
+++ b/CLAUDE_CODE/ai_sales_training/package.json
@@ -13,6 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@supabase/supabase-js": "^2.57.4",
     "@tailwindcss/postcss": "^4.1.13",
     "@types/node": "^22.7.0",
     "@types/react": "^18.3.8",

--- a/CLAUDE_CODE/ai_sales_training/src/App.js
+++ b/CLAUDE_CODE/ai_sales_training/src/App.js
@@ -1,18 +1,33 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useAuth } from './hooks/useAuth';
-import { useProducts } from './hooks/useProducts';
+import { usePersonaLibrary } from './hooks/usePersonaLibrary';
+import { AutomationService } from './utils/automationService';
 
-// Login Component
+const deriveCompanyDomain = (user, profile) => {
+  const profileDomain = profile?.companies?.domain || profile?.company_domain;
+  if (profileDomain) {
+    return profileDomain.toLowerCase();
+  }
+
+  const emailDomain = user?.email?.split('@')[1];
+  if (emailDomain) {
+    return emailDomain.toLowerCase();
+  }
+
+  return null;
+};
+
 const LoginForm = ({ onSwitchToSignup }) => {
   const [formData, setFormData] = useState({ email: '', password: '' });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const { signIn } = useAuth();
 
-  const handleSubmit = async () => {
+  const handleSubmit = async (event) => {
+    event?.preventDefault();
     setLoading(true);
     setError('');
-    const { user, error: authError } = await signIn(formData.email, formData.password);
+    const { error: authError } = await signIn(formData.email, formData.password);
     if (authError) {
       setError(authError);
     }
@@ -28,23 +43,24 @@ const LoginForm = ({ onSwitchToSignup }) => {
           </h2>
           <p className="mt-2 text-center text-sm text-gray-600">Sign in to your account</p>
         </div>
-        
-        <div className="mt-8 space-y-6">
+
+        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
           {error && (
             <div className="rounded-md bg-red-50 p-4">
               <div className="text-sm text-red-700">{error}</div>
             </div>
           )}
-          
+
           <div className="space-y-4">
             <div>
               <label className="block text-sm font-medium text-gray-700">Email address</label>
               <input
                 type="email"
                 value={formData.email}
-                onChange={(e) => setFormData({...formData, email: e.target.value})}
+                onChange={(e) => setFormData({ ...formData, email: e.target.value })}
                 className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
                 placeholder="Enter your email"
+                required
               />
             </div>
             <div>
@@ -52,15 +68,16 @@ const LoginForm = ({ onSwitchToSignup }) => {
               <input
                 type="password"
                 value={formData.password}
-                onChange={(e) => setFormData({...formData, password: e.target.value})}
+                onChange={(e) => setFormData({ ...formData, password: e.target.value })}
                 className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
                 placeholder="Enter your password"
+                required
               />
             </div>
           </div>
 
           <button
-            onClick={handleSubmit}
+            type="submit"
             disabled={loading}
             className="w-full py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50"
           >
@@ -68,24 +85,24 @@ const LoginForm = ({ onSwitchToSignup }) => {
           </button>
 
           <div className="text-center">
-            <button onClick={onSwitchToSignup} className="text-indigo-600 hover:text-indigo-500 text-sm font-medium">
+            <button type="button" onClick={onSwitchToSignup} className="text-indigo-600 hover:text-indigo-500 text-sm font-medium">
               Don't have an account? Sign up
             </button>
           </div>
-        </div>
+        </form>
       </div>
     </div>
   );
 };
 
-// Signup Component
 const SignupForm = ({ onSwitchToLogin }) => {
   const [formData, setFormData] = useState({ email: '', password: '', confirmPassword: '', fullName: '' });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const { signUp } = useAuth();
 
-  const handleSubmit = async () => {
+  const handleSubmit = async (event) => {
+    event?.preventDefault();
     setLoading(true);
     setError('');
 
@@ -101,7 +118,7 @@ const SignupForm = ({ onSwitchToLogin }) => {
       return;
     }
 
-    const { user, error: authError } = await signUp(formData.email, formData.password, formData.fullName);
+    const { error: authError } = await signUp(formData.email, formData.password, formData.fullName);
     if (authError) {
       setError(authError);
     }
@@ -115,47 +132,51 @@ const SignupForm = ({ onSwitchToLogin }) => {
           <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">Join Sales Training Platform</h2>
           <p className="mt-2 text-center text-sm text-gray-600">Create your account to get started</p>
         </div>
-        
-        <div className="mt-8 space-y-6">
+
+        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
           {error && (
             <div className="rounded-md bg-red-50 p-4">
               <div className="text-sm text-red-700">{error}</div>
             </div>
           )}
-          
+
           <div className="space-y-4">
             <input
               type="text"
               placeholder="Full Name"
               value={formData.fullName}
-              onChange={(e) => setFormData({...formData, fullName: e.target.value})}
+              onChange={(e) => setFormData({ ...formData, fullName: e.target.value })}
               className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+              required
             />
             <input
               type="email"
               placeholder="Email address"
               value={formData.email}
-              onChange={(e) => setFormData({...formData, email: e.target.value})}
+              onChange={(e) => setFormData({ ...formData, email: e.target.value })}
               className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+              required
             />
             <input
               type="password"
               placeholder="Password"
               value={formData.password}
-              onChange={(e) => setFormData({...formData, password: e.target.value})}
+              onChange={(e) => setFormData({ ...formData, password: e.target.value })}
               className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+              required
             />
             <input
               type="password"
               placeholder="Confirm Password"
               value={formData.confirmPassword}
-              onChange={(e) => setFormData({...formData, confirmPassword: e.target.value})}
+              onChange={(e) => setFormData({ ...formData, confirmPassword: e.target.value })}
               className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+              required
             />
           </div>
 
           <button
-            onClick={handleSubmit}
+            type="submit"
             disabled={loading}
             className="w-full py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50"
           >
@@ -163,31 +184,431 @@ const SignupForm = ({ onSwitchToLogin }) => {
           </button>
 
           <div className="text-center">
-            <button onClick={onSwitchToLogin} className="text-indigo-600 hover:text-indigo-500 text-sm font-medium">
+            <button type="button" onClick={onSwitchToLogin} className="text-indigo-600 hover:text-indigo-500 text-sm font-medium">
               Already have an account? Sign in
             </button>
           </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+const PersonaSummary = ({ persona }) => {
+  if (!persona) {
+    return (
+      <div className="border border-dashed border-gray-300 rounded-lg p-6 text-center text-gray-500">
+        Select a contact title to preview persona insights.
+      </div>
+    );
+  }
+
+  return (
+    <div className="border border-gray-200 rounded-lg p-6 bg-white shadow-sm">
+      <h3 className="text-xl font-semibold text-gray-800 mb-2">{persona.role}</h3>
+      <p className="text-sm text-blue-600 font-medium mb-4">{persona.company} — {persona.subIndustry}</p>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <h4 className="text-sm font-semibold text-gray-700 mb-2">Personality</h4>
+          <p className="text-sm text-gray-600">{persona.personality}</p>
+        </div>
+        <div>
+          <h4 className="text-sm font-semibold text-gray-700 mb-2">Initial Stance</h4>
+          <p className="text-sm text-gray-600">{persona.initialStance}</p>
+        </div>
+        <div>
+          <h4 className="text-sm font-semibold text-gray-700 mb-2">Top Pain Points</h4>
+          <ul className="list-disc list-inside text-sm text-gray-600 space-y-1">
+            {persona.painPoints.slice(0, 3).map((pain, index) => (
+              <li key={index}>{pain}</li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h4 className="text-sm font-semibold text-gray-700 mb-2">Common Objections</h4>
+          <ul className="list-disc list-inside text-sm text-gray-600 space-y-1">
+            {persona.objections.slice(0, 3).map((objection, index) => (
+              <li key={index}>{objection}</li>
+            ))}
+          </ul>
         </div>
       </div>
     </div>
   );
 };
 
-// Create Product Modal
-const CreateProductModal = ({ isOpen, onClose, onSave }) => {
-  const [formData, setFormData] = useState({
-    name: '',
-    description: '',
-    value_proposition: '',
-    product_type: '',
-    category: ''
-  });
+const AutomationControls = ({
+  testCaseCount,
+  onTestCaseCountChange,
+  onLaunch,
+  isLaunching,
+  result,
+  error,
+  selectedPersona,
+  selectedOffering,
+  companyDomain
+}) => {
+  const isLaunchDisabled = !selectedPersona || !selectedOffering || isLaunching;
 
-  const handleSubmit = () => {
-    if (!formData.name.trim()) {
-      alert('Product name is required');
+  return (
+    <div className="border border-gray-200 rounded-lg p-6 bg-white shadow-sm space-y-4">
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+        <div>
+          <h3 className="text-xl font-semibold text-gray-800">Automation Test Harness</h3>
+          <p className="text-sm text-gray-600">
+            Configure SALES_EXEC automation runs using the current persona context. Domain detected: {companyDomain || 'N/A'}.
+          </p>
+        </div>
+        <div className="flex items-center space-x-3">
+          <label htmlFor="testCases" className="text-sm font-medium text-gray-700">
+            Number of test cases
+          </label>
+          <input
+            id="testCases"
+            type="number"
+            min={1}
+            max={100}
+            value={testCaseCount}
+            onChange={(e) => onTestCaseCountChange(e.target.value)}
+            className="w-24 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+          />
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={onLaunch}
+        disabled={isLaunchDisabled}
+        className={`w-full md:w-auto inline-flex items-center justify-center px-6 py-3 border border-transparent text-sm font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-colors ${
+          isLaunchDisabled
+            ? 'bg-indigo-200 text-white cursor-not-allowed'
+            : 'bg-indigo-600 text-white hover:bg-indigo-700'
+        }`}
+      >
+        {isLaunching ? 'Launching SALES_EXEC...' : 'Launch SALES_EXEC Runs'}
+      </button>
+
+      {result && (
+        <div className="rounded-md bg-green-50 border border-green-200 p-4 text-sm text-green-700">
+          <p className="font-semibold">Automation started successfully.</p>
+          {result.runId && <p>Run ID: {result.runId}</p>}
+          {result.message && <p>{result.message}</p>}
+        </div>
+      )}
+
+      {error && (
+        <div className="rounded-md bg-red-50 border border-red-200 p-4 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const App = () => {
+  const { user, profile, loading, signOut } = useAuth();
+  const [showSignup, setShowSignup] = useState(false);
+
+  const companyDomain = useMemo(() => deriveCompanyDomain(user, profile), [user, profile]);
+
+  const { data: personaLibrary, loading: personaLoading, error: personaError } = usePersonaLibrary(companyDomain);
+
+  const [selectedOfferingId, setSelectedOfferingId] = useState('');
+  const [selectedIndustryId, setSelectedIndustryId] = useState('');
+  const [selectedSubIndustryId, setSelectedSubIndustryId] = useState('');
+  const [selectedPersonaId, setSelectedPersonaId] = useState('');
+  const [testCaseCount, setTestCaseCount] = useState(10);
+  const [isLaunching, setIsLaunching] = useState(false);
+  const [automationResult, setAutomationResult] = useState(null);
+  const [automationError, setAutomationError] = useState(null);
+
+  useEffect(() => {
+    if (!personaLibrary) {
+      setSelectedOfferingId('');
+      setSelectedIndustryId('');
+      setSelectedSubIndustryId('');
+      setSelectedPersonaId('');
       return;
     }
-    onSave(formData);
-    setFormData({
-      name
+
+    const { offerings, defaultSelections } = personaLibrary;
+    if (!offerings?.length) return;
+
+    setSelectedOfferingId((prev) => {
+      if (offerings.some((offering) => offering.id === prev)) {
+        return prev;
+      }
+      return defaultSelections.offeringId || offerings[0].id;
+    });
+  }, [personaLibrary]);
+
+  useEffect(() => {
+    if (!personaLibrary || !selectedOfferingId) return;
+
+    const offering = personaLibrary.offerings.find((item) => item.id === selectedOfferingId);
+    if (!offering) {
+      setSelectedIndustryId('');
+      return;
+    }
+
+    setSelectedIndustryId((prev) => {
+      if (offering.industries?.some((industry) => industry.id === prev)) {
+        return prev;
+      }
+      return offering.industries?.[0]?.id || '';
+    });
+  }, [personaLibrary, selectedOfferingId]);
+
+  useEffect(() => {
+    if (!personaLibrary || !selectedOfferingId || !selectedIndustryId) return;
+
+    const offering = personaLibrary.offerings.find((item) => item.id === selectedOfferingId);
+    const industry = offering?.industries?.find((item) => item.id === selectedIndustryId);
+
+    if (!industry) {
+      setSelectedSubIndustryId('');
+      return;
+    }
+
+    setSelectedSubIndustryId((prev) => {
+      if (industry.subIndustries?.some((sub) => sub.id === prev)) {
+        return prev;
+      }
+      return industry.subIndustries?.[0]?.id || '';
+    });
+  }, [personaLibrary, selectedOfferingId, selectedIndustryId]);
+
+  const personaOptions = useMemo(() => {
+    if (!personaLibrary || !selectedOfferingId || !selectedIndustryId || !selectedSubIndustryId) {
+      return [];
+    }
+
+    const offering = personaLibrary.offerings.find((item) => item.id === selectedOfferingId);
+    const industry = offering?.industries?.find((item) => item.id === selectedIndustryId);
+    const subIndustry = industry?.subIndustries?.find((item) => item.id === selectedSubIndustryId);
+
+    return subIndustry?.personas || [];
+  }, [personaLibrary, selectedOfferingId, selectedIndustryId, selectedSubIndustryId]);
+
+  useEffect(() => {
+    if (!personaOptions.length) {
+      setSelectedPersonaId('');
+      return;
+    }
+
+    setSelectedPersonaId((prev) => {
+      if (personaOptions.some((option) => option.id === prev)) {
+        return prev;
+      }
+      return personaOptions[0].id;
+    });
+  }, [personaOptions]);
+
+  useEffect(() => {
+    if (!personaLibrary?.metadata) return;
+    if (typeof personaLibrary.metadata.defaultTestCaseCount === 'number') {
+      setTestCaseCount(personaLibrary.metadata.defaultTestCaseCount);
+    }
+  }, [personaLibrary]);
+
+  const selectedPersona = useMemo(() => {
+    if (!personaLibrary || !selectedPersonaId) return null;
+    return personaLibrary.personas[selectedPersonaId] || null;
+  }, [personaLibrary, selectedPersonaId]);
+
+  const selectedOffering = useMemo(() => {
+    if (!personaLibrary) return null;
+    return personaLibrary.offerings.find((item) => item.id === selectedOfferingId) || null;
+  }, [personaLibrary, selectedOfferingId]);
+
+  const handleTestCaseCountChange = (value) => {
+    const numericValue = Number(value);
+    if (Number.isNaN(numericValue)) return;
+    const bounded = Math.min(100, Math.max(1, Math.floor(numericValue)));
+    setTestCaseCount(bounded);
+  };
+
+  const handleLaunchAutomation = async () => {
+    if (!selectedPersona || !selectedOffering) return;
+
+    setIsLaunching(true);
+    setAutomationResult(null);
+    setAutomationError(null);
+
+    const { data, error } = await AutomationService.launchSalesExecRuns({
+      testCaseCount,
+      offeringId: selectedOfferingId,
+      industryId: selectedIndustryId,
+      subIndustryId: selectedSubIndustryId,
+      personaId: selectedPersonaId,
+      contactTitle: selectedPersona.role,
+      companyDomain,
+      metadata: {
+        offeringName: selectedOffering.name,
+        personaRole: selectedPersona.role
+      }
+    });
+
+    if (error) {
+      setAutomationError(error);
+    } else {
+      setAutomationResult(data);
+    }
+
+    setIsLaunching(false);
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto" />
+          <p className="mt-4 text-gray-600">Checking authentication status...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return showSignup ? (
+      <SignupForm onSwitchToLogin={() => setShowSignup(false)} />
+    ) : (
+      <LoginForm onSwitchToSignup={() => setShowSignup(true)} />
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="bg-white shadow-sm">
+        <div className="max-w-6xl mx-auto px-6 py-4 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">AI Sales Training Orchestrator</h1>
+            <p className="text-sm text-gray-600">
+              Signed in as {profile?.full_name || user.email} · {companyDomain || 'Domain not detected'}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={signOut}
+            className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-indigo-600 bg-indigo-100 hover:bg-indigo-200"
+          >
+            Sign out
+          </button>
+        </div>
+      </header>
+
+      <main className="max-w-6xl mx-auto px-6 py-8 space-y-8">
+        <section className="bg-white shadow-sm rounded-lg p-6 space-y-6">
+          <div>
+            <h2 className="text-xl font-semibold text-gray-800">Persona Context</h2>
+            <p className="text-sm text-gray-600">
+              Choose the offering, industry, and buyer persona to seed automation and practice scenarios.
+            </p>
+          </div>
+
+          {personaError && (
+            <div className="rounded-md bg-red-50 border border-red-200 p-4 text-sm text-red-700">
+              {personaError}
+            </div>
+          )}
+
+          {personaLoading ? (
+            <div className="flex items-center justify-center py-12">
+              <div className="text-center">
+                <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-indigo-600 mx-auto" />
+                <p className="mt-3 text-gray-600">Loading persona library...</p>
+              </div>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <div className="space-y-5">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700">Offering</label>
+                  <select
+                    value={selectedOfferingId}
+                    onChange={(e) => setSelectedOfferingId(e.target.value)}
+                    className="mt-1 block w-full px-3 py-2 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+                  >
+                    {(personaLibrary?.offerings || []).map((offering) => (
+                      <option key={offering.id} value={offering.id}>
+                        {offering.name}
+                      </option>
+                    ))}
+                  </select>
+                  {selectedOffering?.description && (
+                    <p className="mt-2 text-sm text-gray-500">{selectedOffering.description}</p>
+                  )}
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700">Industry</label>
+                  <select
+                    value={selectedIndustryId}
+                    onChange={(e) => setSelectedIndustryId(e.target.value)}
+                    className="mt-1 block w-full px-3 py-2 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+                  >
+                    {(selectedOffering?.industries || []).map((industry) => (
+                      <option key={industry.id} value={industry.id}>
+                        {industry.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700">Sub-industry</label>
+                  <select
+                    value={selectedSubIndustryId}
+                    onChange={(e) => setSelectedSubIndustryId(e.target.value)}
+                    className="mt-1 block w-full px-3 py-2 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+                  >
+                    {(
+                      selectedOffering?.industries
+                        ?.find((industry) => industry.id === selectedIndustryId)
+                        ?.subIndustries || []
+                    ).map((subIndustry) => (
+                      <option key={subIndustry.id} value={subIndustry.id}>
+                        {subIndustry.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700">Contact title</label>
+                  <select
+                    value={selectedPersonaId}
+                    onChange={(e) => setSelectedPersonaId(e.target.value)}
+                    className="mt-1 block w-full px-3 py-2 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+                  >
+                    {personaOptions.map((option) => (
+                      <option key={option.id} value={option.id}>
+                        {option.title}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+
+              <PersonaSummary persona={selectedPersona} />
+            </div>
+          )}
+        </section>
+
+        <AutomationControls
+          testCaseCount={testCaseCount}
+          onTestCaseCountChange={handleTestCaseCountChange}
+          onLaunch={handleLaunchAutomation}
+          isLaunching={isLaunching}
+          result={automationResult}
+          error={automationError}
+          selectedPersona={selectedPersona}
+          selectedOffering={selectedOffering}
+          companyDomain={companyDomain}
+        />
+      </main>
+    </div>
+  );
+};
+
+export default App;

--- a/CLAUDE_CODE/ai_sales_training/src/App.tsx
+++ b/CLAUDE_CODE/ai_sales_training/src/App.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import App from './App';
+
+const RootApp: React.FC = () => <App />;
+
+export default RootApp;

--- a/CLAUDE_CODE/ai_sales_training/src/hooks/usePersonaLibrary.js
+++ b/CLAUDE_CODE/ai_sales_training/src/hooks/usePersonaLibrary.js
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+import { personaLoader } from '../utils/personaLoader';
+
+export const usePersonaLibrary = (companyDomain) => {
+  const [state, setState] = useState({
+    data: null,
+    loading: true,
+    error: null
+  });
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const load = async () => {
+      setState((prev) => ({ ...prev, loading: true, error: null }));
+
+      try {
+        const library = await personaLoader.loadPersonaLibrary(companyDomain);
+        if (!isMounted) return;
+        setState({ data: library, loading: false, error: null });
+      } catch (error) {
+        console.error('Failed to load persona library:', error);
+        if (!isMounted) return;
+        setState({ data: null, loading: false, error: error.message || 'Failed to load persona library' });
+      }
+    };
+
+    load();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [companyDomain]);
+
+  return state;
+};

--- a/CLAUDE_CODE/ai_sales_training/src/personas/persona-library.json
+++ b/CLAUDE_CODE/ai_sales_training/src/personas/persona-library.json
@@ -1,0 +1,72 @@
+{
+  "metadata": {
+    "version": "2025.02",
+    "description": "Persona library definitions organized by offering and industry",
+    "defaultTestCaseCount": 10
+  },
+  "offerings": [
+    {
+      "id": "productivity-security-suite",
+      "name": "ProductivityPro Security Suite",
+      "description": "Comprehensive productivity and security platform built for professional services organizations.",
+      "industries": [
+        {
+          "id": "professional-services",
+          "name": "Professional Services",
+          "subIndustries": [
+            {
+              "id": "law-firms",
+              "name": "Law Firms",
+              "personas": [
+                "law-managing-partner",
+                "law-it-director"
+              ]
+            },
+            {
+              "id": "accounting-firms",
+              "name": "Accounting Firms",
+              "personas": [
+                "accounting-managing-partner",
+                "accounting-it-manager"
+              ]
+            },
+            {
+              "id": "consulting-firms",
+              "name": "Consulting Firms",
+              "personas": [
+                "consulting-managing-director",
+                "consulting-operations-manager"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "defaultSelections": {
+    "offeringId": "productivity-security-suite",
+    "industryId": "professional-services",
+    "subIndustryId": "law-firms",
+    "personaId": "law-managing-partner"
+  },
+  "domainOverrides": {
+    "lexlaw.com": {
+      "offeringId": "productivity-security-suite",
+      "industryId": "professional-services",
+      "subIndustryId": "law-firms",
+      "personaId": "law-managing-partner"
+    },
+    "numbersandco.com": {
+      "offeringId": "productivity-security-suite",
+      "industryId": "professional-services",
+      "subIndustryId": "accounting-firms",
+      "personaId": "accounting-managing-partner"
+    },
+    "proconsulting.io": {
+      "offeringId": "productivity-security-suite",
+      "industryId": "professional-services",
+      "subIndustryId": "consulting-firms",
+      "personaId": "consulting-managing-director"
+    }
+  }
+}

--- a/CLAUDE_CODE/ai_sales_training/src/utils/automationService.js
+++ b/CLAUDE_CODE/ai_sales_training/src/utils/automationService.js
@@ -1,0 +1,61 @@
+const DEFAULT_AUTOMATION_BASE_URL = '/api/automation';
+
+const buildUrl = (path = '') => {
+  const base = process.env.REACT_APP_AUTOMATION_API_BASE_URL || DEFAULT_AUTOMATION_BASE_URL;
+  const normalizedBase = base.endsWith('/') ? base.slice(0, -1) : base;
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return `${normalizedBase}${normalizedPath}`;
+};
+
+export class AutomationService {
+  static async launchSalesExecRuns({
+    testCaseCount,
+    offeringId,
+    industryId,
+    subIndustryId,
+    personaId,
+    contactTitle,
+    companyDomain,
+    metadata = {}
+  }) {
+    try {
+      const response = await fetch(buildUrl('/runs'), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          workflow: 'SALES_EXEC',
+          testCases: Number(testCaseCount) || 1,
+          context: {
+            offeringId,
+            industryId,
+            subIndustryId,
+            personaId,
+            contactTitle,
+            companyDomain,
+            metadata
+          }
+        })
+      });
+
+      if (!response.ok) {
+        let message = `Automation request failed with status ${response.status}`;
+        try {
+          const errorBody = await response.json();
+          if (errorBody?.error) {
+            message = errorBody.error;
+          }
+        } catch (parseError) {
+          // Ignore JSON parse errors and fall back to default message
+        }
+        throw new Error(message);
+      }
+
+      const data = await response.json();
+      return { data, error: null };
+    } catch (error) {
+      return { data: null, error: error.message || 'Unable to launch automation run' };
+    }
+  }
+}

--- a/CLAUDE_CODE/ai_sales_training/src/utils/personaLoader.js
+++ b/CLAUDE_CODE/ai_sales_training/src/utils/personaLoader.js
@@ -1,75 +1,182 @@
-// Persona loader utility for dynamic persona loading
+import manifest from '../personas/personas-manifest.json';
+import personaLibraryDefinition from '../personas/persona-library.json';
+
+const PERSONA_IMPORTERS = {
+  'Professional_Services/Law_Firms/managing-partner.json': () => import('../personas/Professional_Services/Law_Firms/managing-partner.json'),
+  'Professional_Services/Law_Firms/it-director.json': () => import('../personas/Professional_Services/Law_Firms/it-director.json'),
+  'Professional_Services/Accounting_Firms/managing-partner.json': () => import('../personas/Professional_Services/Accounting_Firms/managing-partner.json'),
+  'Professional_Services/Accounting_Firms/it-manager.json': () => import('../personas/Professional_Services/Accounting_Firms/it-manager.json'),
+  'Professional_Services/Consulting_Firms/managing-director.json': () => import('../personas/Professional_Services/Consulting_Firms/managing-director.json'),
+  'Professional_Services/Consulting_Firms/operations-manager.json': () => import('../personas/Professional_Services/Consulting_Firms/operations-manager.json')
+};
+
+// Persona loader utility for dynamic persona loading that is aware of the persona-library manifest
 export class PersonaLoader {
   constructor() {
     this.personas = {};
     this.loaded = false;
+    this.libraryCache = new Map();
   }
 
-  // Load all personas from JSON files
-  async loadAllPersonas() {
-    if (this.loaded) return this.personas;
+  async ensurePersonasLoaded() {
+    if (this.loaded) {
+      return;
+    }
 
     try {
-      // Import all persona JSON files
-      const lawManagingPartner = await import('../personas/Professional_Services/Law_Firms/managing-partner.json');
-      const lawItDirector = await import('../personas/Professional_Services/Law_Firms/it-director.json');
-      const accountingManagingPartner = await import('../personas/Professional_Services/Accounting_Firms/managing-partner.json');
-      const accountingItManager = await import('../personas/Professional_Services/Accounting_Firms/it-manager.json');
-      const consultingManagingDirector = await import('../personas/Professional_Services/Consulting_Firms/managing-director.json');
-      const consultingOperationsManager = await import('../personas/Professional_Services/Consulting_Firms/operations-manager.json');
+      const personaEntries = await Promise.all(
+        manifest.personas.map(async (personaMeta) => {
+          const importer = PERSONA_IMPORTERS[personaMeta.file];
 
-      // Add to personas object using their IDs
-      this.personas[lawManagingPartner.default.id] = lawManagingPartner.default;
-      this.personas[lawItDirector.default.id] = lawItDirector.default;
-      this.personas[accountingManagingPartner.default.id] = accountingManagingPartner.default;
-      this.personas[accountingItManager.default.id] = accountingItManager.default;
-      this.personas[consultingManagingDirector.default.id] = consultingManagingDirector.default;
-      this.personas[consultingOperationsManager.default.id] = consultingOperationsManager.default;
+          if (!importer) {
+            console.warn(`No importer registered for persona file ${personaMeta.file}`);
+            return null;
+          }
+
+          try {
+            const module = await importer();
+            const persona = module?.default;
+
+            if (!persona?.id) {
+              console.warn(`Persona payload for ${personaMeta.file} is missing an id.`);
+              return null;
+            }
+
+            return [persona.id, persona];
+          } catch (error) {
+            console.error(`Failed to import persona file ${personaMeta.file}:`, error);
+            return null;
+          }
+        })
+      );
+
+      personaEntries
+        .filter(Boolean)
+        .forEach(([id, persona]) => {
+          this.personas[id] = persona;
+        });
 
       this.loaded = true;
-      return this.personas;
     } catch (error) {
-      console.error('Error loading personas:', error);
-      return {};
+      console.error('Error loading personas from manifest:', error);
+      this.personas = {};
+      this.loaded = true;
     }
   }
 
-  // Get personas by industry
-  getPersonasByIndustry(industry) {
-    return Object.values(this.personas).filter(persona => 
-      persona.industry === industry
+  async loadAllPersonas() {
+    await this.ensurePersonasLoaded();
+    return this.personas;
+  }
+
+  normalizeDomain(domain) {
+    if (!domain) return null;
+    const trimmed = domain.trim().toLowerCase();
+    if (!trimmed) return null;
+
+    const withoutProtocol = trimmed.replace(/^https?:\/\//, '');
+    const withoutPath = withoutProtocol.split('/')[0];
+    const withoutWww = withoutPath.startsWith('www.') ? withoutPath.slice(4) : withoutPath;
+
+    return withoutWww;
+  }
+
+  resolveDomainOverride(normalizedDomain) {
+    if (!normalizedDomain) {
+      return null;
+    }
+
+    const overrides = personaLibraryDefinition.domainOverrides || {};
+    const baseDomain = normalizedDomain.split('.').slice(-2).join('.');
+
+    return (
+      overrides[normalizedDomain] ||
+      overrides[baseDomain] ||
+      null
     );
   }
 
-  // Get personas by sub-industry
-  getPersonasBySubIndustry(subIndustry) {
-    return Object.values(this.personas).filter(persona => 
-      persona.subIndustry === subIndustry
-    );
+  sanitizeSelections(offerings, desiredSelections = {}) {
+    const findOffering = (id) => offerings.find((offering) => offering.id === id);
+    const findIndustry = (offering, id) => offering?.industries?.find((industry) => industry.id === id);
+    const findSubIndustry = (industry, id) => industry?.subIndustries?.find((sub) => sub.id === id);
+    const findPersona = (subIndustry, id) => subIndustry?.personas?.find((persona) => persona.id === id);
+
+    const fallbackOffering = findOffering(desiredSelections.offeringId) || offerings[0] || null;
+    const fallbackIndustry = findIndustry(fallbackOffering, desiredSelections.industryId) || fallbackOffering?.industries?.[0] || null;
+    const fallbackSubIndustry = findSubIndustry(fallbackIndustry, desiredSelections.subIndustryId) || fallbackIndustry?.subIndustries?.[0] || null;
+    const fallbackPersona = findPersona(fallbackSubIndustry, desiredSelections.personaId) || fallbackSubIndustry?.personas?.[0] || null;
+
+    return {
+      offeringId: fallbackOffering?.id || '',
+      industryId: fallbackIndustry?.id || '',
+      subIndustryId: fallbackSubIndustry?.id || '',
+      personaId: fallbackPersona?.id || ''
+    };
   }
 
-  // Get persona by ID
-  getPersonaById(id) {
-    return this.personas[id];
+  buildOfferings() {
+    return (personaLibraryDefinition.offerings || []).map((offering) => ({
+      id: offering.id,
+      name: offering.name,
+      description: offering.description,
+      industries: (offering.industries || []).map((industry) => ({
+        id: industry.id,
+        name: industry.name,
+        subIndustries: (industry.subIndustries || []).map((subIndustry) => ({
+          id: subIndustry.id,
+          name: subIndustry.name,
+          personas: (subIndustry.personas || [])
+            .map((personaId) => {
+              const persona = this.personas[personaId];
+
+              if (!persona) {
+                console.warn(`Persona ${personaId} referenced in library but not present in manifest data.`);
+                return null;
+              }
+
+              return {
+                id: personaId,
+                title: persona.role,
+                persona
+              };
+            })
+            .filter(Boolean)
+        }))
+      }))
+    }));
   }
 
-  // Get all unique industries
-  getIndustries() {
-    return [...new Set(Object.values(this.personas).map(p => p.industry))];
-  }
+  async loadPersonaLibrary(companyDomain) {
+    await this.ensurePersonasLoaded();
 
-  // Get all unique sub-industries
-  getSubIndustries() {
-    return [...new Set(Object.values(this.personas).map(p => p.subIndustry))];
-  }
+    const normalizedDomain = this.normalizeDomain(companyDomain);
+    const cacheKey = normalizedDomain || '__default__';
 
-  // Get sub-industries for a specific industry
-  getSubIndustriesForIndustry(industry) {
-    return [...new Set(
-      Object.values(this.personas)
-        .filter(p => p.industry === industry)
-        .map(p => p.subIndustry)
-    )];
+    if (this.libraryCache.has(cacheKey)) {
+      return this.libraryCache.get(cacheKey);
+    }
+
+    const offerings = this.buildOfferings();
+    const overrideSelections = this.resolveDomainOverride(normalizedDomain);
+
+    const combinedSelections = {
+      ...personaLibraryDefinition.defaultSelections,
+      ...overrideSelections
+    };
+
+    const defaultSelections = this.sanitizeSelections(offerings, combinedSelections);
+
+    const payload = {
+      metadata: personaLibraryDefinition.metadata || {},
+      personas: this.personas,
+      offerings,
+      defaultSelections,
+      domain: normalizedDomain
+    };
+
+    this.libraryCache.set(cacheKey, payload);
+    return payload;
   }
 }
 

--- a/CLAUDE_CODE/ai_sales_training/src/utils/supabase.js
+++ b/CLAUDE_CODE/ai_sales_training/src/utils/supabase.js
@@ -9,80 +9,86 @@ if (!supabaseUrl || !supabaseAnonKey) {
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey)
 
-// Database types for TypeScript
-export interface Company {
-  id: string
-  name: string
-  domain: string
-  created_at: string
-  updated_at: string
-}
+// JSDoc typedefs are provided for editor IntelliSense without breaking the build pipeline
+/**
+ * @typedef {Object} Company
+ * @property {string} id
+ * @property {string} name
+ * @property {string} domain
+ * @property {string} created_at
+ * @property {string} updated_at
+ */
 
-export interface UserProfile {
-  id: string
-  email: string
-  full_name?: string
-  company_id: string
-  role: 'admin' | 'user'
-  created_at: string
-  updated_at: string
-  companies?: Company
-}
+/**
+ * @typedef {Object} UserProfile
+ * @property {string} id
+ * @property {string} email
+ * @property {string=} full_name
+ * @property {string} company_id
+ * @property {'admin'|'user'} role
+ * @property {string} created_at
+ * @property {string} updated_at
+ * @property {Company=} companies
+ */
 
-export interface Product {
-  id: string
-  company_id: string
-  name: string
-  description?: string
-  value_proposition?: string
-  product_type?: string
-  category?: string
-  configuration: any
-  raw_content?: string
-  is_active: boolean
-  created_by: string
-  created_at: string
-  updated_at: string
-  user_profiles?: { full_name: string }
-  product_documents?: ProductDocument[]
-  product_urls?: ProductUrl[]
-}
+/**
+ * @typedef {Object} ProductDocument
+ * @property {string} id
+ * @property {string} product_id
+ * @property {string} filename
+ * @property {string} file_type
+ * @property {number} file_size
+ * @property {string} storage_path
+ * @property {string=} extracted_content
+ * @property {string} uploaded_by
+ * @property {string} created_at
+ */
 
-export interface ProductDocument {
-  id: string
-  product_id: string
-  filename: string
-  file_type: string
-  file_size: number
-  storage_path: string
-  extracted_content?: string
-  uploaded_by: string
-  created_at: string
-}
+/**
+ * @typedef {Object} ProductUrl
+ * @property {string} id
+ * @property {string} product_id
+ * @property {string} url
+ * @property {string=} title
+ * @property {string=} extracted_content
+ * @property {'pending'|'processed'|'failed'} status
+ * @property {string} added_by
+ * @property {string} created_at
+ */
 
-export interface ProductUrl {
-  id: string
-  product_id: string
-  url: string
-  title?: string
-  extracted_content?: string
-  status: 'pending' | 'processed' | 'failed'
-  added_by: string
-  created_at: string
-}
+/**
+ * @typedef {Object} Product
+ * @property {string} id
+ * @property {string} company_id
+ * @property {string} name
+ * @property {string=} description
+ * @property {string=} value_proposition
+ * @property {string=} product_type
+ * @property {string=} category
+ * @property {*} configuration
+ * @property {string=} raw_content
+ * @property {boolean} is_active
+ * @property {string} created_by
+ * @property {string} created_at
+ * @property {string} updated_at
+ * @property {{ full_name: string }=} user_profiles
+ * @property {ProductDocument[]=} product_documents
+ * @property {ProductUrl[]=} product_urls
+ */
 
-export interface TrainingSession {
-  id: string
-  company_id: string
-  product_id: string
-  user_id: string
-  session_type: 'human_practice' | 'ai_simulation'
-  persona_id: string
-  pitch_type: string
-  llm_model: string
-  conversation_data: any
-  results: any
-  duration_minutes?: number
-  success_rate?: number
-  created_at: string
-}
+/**
+ * @typedef {Object} TrainingSession
+ * @property {string} id
+ * @property {string} company_id
+ * @property {string} product_id
+ * @property {string} user_id
+ * @property {'human_practice'|'ai_simulation'} session_type
+ * @property {string} persona_id
+ * @property {string} pitch_type
+ * @property {string} llm_model
+ * @property {*} conversation_data
+ * @property {*} results
+ * @property {number=} duration_minutes
+ * @property {number=} success_rate
+ * @property {string} created_at
+ */


### PR DESCRIPTION
## Summary
- derive the company domain from the authenticated user and drive persona selection controls instead of the Supabase product workflow
- load persona metadata from the persona library manifest with domain-aware defaults via a dedicated hook
- add an automation service and UI controls so SALES_EXEC runs can be launched with the selected persona context and test count

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd269064d483269d2f0d44699aa6bf